### PR TITLE
How to customize grids? Customizing grids by events

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -42,6 +42,14 @@ default:
 
         FriendsOfBehat\SymfonyExtension: ~
 
+        FriendsOfBehat\ExcludeSpecificationsExtension:
+            features:
+                - "vendor/sylius/sylius/features/product/managing_product_reviews/deleting_product_review.feature"
+                - "vendor/sylius/sylius/features/product/managing_product_reviews/recalculating_product_average_rating.feature"
+                - "vendor/sylius/sylius/features/product/managing_products/prevent_deletion_of_purchased_product.feature"
+                - "vendor/sylius/sylius/features/checkout/addressing_order/specifying_province_manually.feature"
+                - "vendor/sylius/sylius/features/product/managing_products/select_taxons_for_new_product.feature"
+
         FriendsOfBehat\VariadicExtension: ~
 
         FriendsOfBehat\SuiteSettingsExtension:

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -265,3 +265,8 @@ sylius_grid:
             filters:
                 title:
                     enabled: false
+            actions:
+                item:
+                    delete:
+                        type: delete
+                        enabled: false

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -255,3 +255,10 @@ sylius_theme:
         filesystem:
             directories:
                 - "%kernel.project_dir%/themes"
+
+sylius_grid:
+    grids:
+        sylius_admin_product_review:
+            fields:
+                title:
+                    enabled: false

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -260,7 +260,8 @@ sylius_grid:
     grids:
         sylius_admin_product_review:
             fields:
-                title:
-                    enabled: false
                 date:
                     label: "When was it added?"
+            filters:
+                title:
+                    enabled: false

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -270,3 +270,14 @@ sylius_grid:
                     delete:
                         type: delete
                         enabled: false
+        sylius_admin_product:
+            actions:
+                item:
+                    show:
+                        type: show
+                        label: Show in the shop
+                        options:
+                            link:
+                                route: sylius_shop_product_show
+                                parameters:
+                                    slug: resource.slug

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -261,7 +261,17 @@ sylius_grid:
         sylius_admin_product_review:
             fields:
                 date:
-                    label: "When was it added?"
+                    position: 5
+                title:
+                    position: 6
+                rating:
+                    position: 3
+                status:
+                    position: 1
+                reviewSubject:
+                    position: 2
+                author:
+                    position: 4
             filters:
                 title:
                     enabled: false

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -262,3 +262,5 @@ sylius_grid:
             fields:
                 title:
                     enabled: false
+                date:
+                    label: "When was it added?"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -27,3 +27,7 @@ services:
     App\Controller\:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
+
+    App\Grid\AdminProductsGridListener:
+        tags:
+            - { name: kernel.event_listener, event: sylius.grid.admin_product, method: removeImageField }

--- a/src/Grid/AdminProductsGridListener.php
+++ b/src/Grid/AdminProductsGridListener.php
@@ -8,7 +8,7 @@ use Sylius\Component\Grid\Event\GridDefinitionConverterEvent;
 
 final class AdminProductsGridListener
 {
-    public function removeImageField(GridDefinitionConverterEvent $event): void 
+    public function removeImageField(GridDefinitionConverterEvent $event): void
     {
         $grid = $event->getGrid();
 

--- a/src/Grid/AdminProductsGridListener.php
+++ b/src/Grid/AdminProductsGridListener.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Grid;
+
+use Sylius\Component\Grid\Event\GridDefinitionConverterEvent;
+
+final class AdminProductsGridListener
+{
+    public function removeImageField(GridDefinitionConverterEvent $event): void 
+    {
+        $grid = $event->getGrid();
+
+        $grid->removeField('image');
+    }
+}


### PR DESCRIPTION
[Docs - Customizing Grids](https://docs.sylius.com/en/1.4/customization/grid.html)

**How to remove a field from a grid?(Remove "Title")
How to modify a field of a grid?(Rename "Date" to "When was it added?")**

Before:
![Screenshot 2019-05-06 at 09 57 35](https://user-images.githubusercontent.com/39232096/57216243-9ccc1c80-6fef-11e9-8020-16251b8d7993.png)

After: 
![Screenshot 2019-05-06 at 09 58 54](https://user-images.githubusercontent.com/39232096/57216266-ace3fc00-6fef-11e9-9488-4b9e05a03aec.png)

**How to remove a filter from a grid?(Remove "Filters")**

Before:
![Screenshot 2019-05-06 at 10 28 01](https://user-images.githubusercontent.com/39232096/57216317-d3a23280-6fef-11e9-91db-fdcf614905b8.png)

After:
![Screenshot 2019-05-06 at 10 30 36](https://user-images.githubusercontent.com/39232096/57216341-df8df480-6fef-11e9-9826-512ae1b632a0.png)

**How to remove an action from a grid?(Remove "Delete" buttons)**

Before:
![Screenshot 2019-05-06 at 10 31 03](https://user-images.githubusercontent.com/39232096/57216367-f896a580-6fef-11e9-9a45-a1d1fd8d3394.png)

After:
![Screenshot 2019-05-06 at 10 33 13](https://user-images.githubusercontent.com/39232096/57216380-03e9d100-6ff0-11e9-9a24-0e6480e0c3c2.png)

**How to modify an action of a grid?(Add "Show in the shop" button)**

Before:
![Screenshot 2019-05-06 at 10 46 47](https://user-images.githubusercontent.com/39232096/57216798-2b8d6900-6ff1-11e9-896c-dfa42d0703ea.png)

After:
![Screenshot 2019-05-06 at 10 44 05](https://user-images.githubusercontent.com/39232096/57216414-18c66480-6ff0-11e9-9fa3-1f45db0aa62c.png)

**How to modify positions of fields, filters and actions in a grid?**

After:
![Screenshot 2019-05-06 at 10 51 19](https://user-images.githubusercontent.com/39232096/57216478-3abfe700-6ff0-11e9-8284-0fd6e3c3add8.png)

**Customizing grids by events(Remove "Image" column)**

Before:
![Screenshot 2019-05-06 at 11 00 01](https://user-images.githubusercontent.com/39232096/57216559-76f34780-6ff0-11e9-8421-eaae5a81f55e.png)

After:
![Screenshot 2019-05-06 at 11 01 51](https://user-images.githubusercontent.com/39232096/57216529-5925e280-6ff0-11e9-9b65-ac69a5f1e1f1.png)



